### PR TITLE
chore: refresh python-dotenv dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **Dependency refresh:** Updated `python-dotenv` to 1.2.2 for runtime configuration loading.
+
 ## [v2.3.8] - 2026-05-27
 
 ### Changed

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ httpx==0.28.1
 itsdangerous==2.2.0
 msal==1.32.3
 opentelemetry-instrumentation-httpx==0.52b1
-python-dotenv==1.1.1
+python-dotenv==1.2.2
 starlette
 tenacity==9.1.2
 uvicorn==0.35.0


### PR DESCRIPTION
## Summary
- Updates python-dotenv to 1.2.2.
- Documents the dependency refresh in the changelog.

## Validation
- Verified python-dotenv 1.2.2 imports and dotenv parsing in an isolated Python environment.