### PR TITLE
fix: forward uploader oid as securityUserIds to ingestion (#478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Forward uploader identity for document ACLs (issue #478):** The ingestion payload built by `ingestion_client.py` now includes the authenticated uploader's object id as `securityUserIds` so the ingestion service can stamp document ACLs. This keeps uploaded documents retrievable by their uploader on permission-trimmed search indexes. Anonymous/placeholder ids are not sent.
 
 ## [v2.3.9] - 2026-05-27
 

--- a/ingestion_client.py
+++ b/ingestion_client.py
@@ -103,7 +103,7 @@ def _ingest_response_failure_detail(body: object) -> Optional[str]:
     return "; ".join(messages[:cap]) + tail
 
 
-async def _build_ingest_documents_payload(conversation_id: str, question_id: str, files: list[dict]) -> dict:
+async def _build_ingest_documents_payload(conversation_id: str, question_id: str, files: list[dict], auth_info: dict | None = None) -> dict:
     cid = (conversation_id or "").strip() or (question_id or "").strip() or str(uuid.uuid4())
 
     to_process = files[:_MAX_INGEST_FILES]
@@ -164,7 +164,17 @@ async def _build_ingest_documents_payload(conversation_id: str, question_id: str
             }
         )
 
-    return {"conversationId": cid, "values": values}
+    payload: dict = {"conversationId": cid, "values": values}
+
+    # Stamp the uploader's object id as the document ACL so that, when the
+    # search index has permission trimming enabled, the uploader can retrieve
+    # their own uploaded chunks (issue #478). Skip anonymous/placeholder ids.
+    _ACL_PLACEHOLDERS = {"", "no-auth", "anonymous", "00000000-0000-0000-0000-000000000000"}
+    uploader_oid = ((auth_info or {}).get("client_principal_id") or "").strip()
+    if uploader_oid and uploader_oid.lower() not in _ACL_PLACEHOLDERS:
+        payload["securityUserIds"] = [uploader_oid]
+
+    return payload
 
 
 async def ingest_files_session(conversation_id: str, question_id: str, auth_info: dict, files: list[dict]) -> bool:
@@ -191,7 +201,7 @@ async def ingest_files_session(conversation_id: str, question_id: str, auth_info
     if access_token:
         headers["Authorization"] = f"Bearer {access_token}"
 
-    payload = await _build_ingest_documents_payload(conversation_id, question_id, files)
+    payload = await _build_ingest_documents_payload(conversation_id, question_id, files, auth_info)
 
     logger.info(
         "Invoking ingestion: question_id=%s conversation_id=%s mode=%s url=%s headers=%s files_count=%d",


### PR DESCRIPTION
## Summary
Hardening for [Azure/GPT-RAG#478](https://github.com/Azure/GPT-RAG/issues/478). The ingest payload did not carry the uploader identity, so the ingestion service could not populate document ACLs.

## Changes
- Include the authenticated uploader's object id (`auth_info['client_principal_id']`) as `securityUserIds` in the `/ingest-documents` payload.
- Skip anonymous/placeholder ids (`no-auth`, `anonymous`, zero-GUID).

## Companion PRs
- Azure/gpt-rag-orchestrator `fix/document-upload-rag-478` (keystone retrieval fix)
- Azure/gpt-rag-ingestion `fix/document-upload-rag-478` (ACL stamping)