### PR TITLE
docs: require version-only release titles

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -114,6 +114,9 @@ In this repository:
 - release branch names do NOT use the `v` prefix
 - the root `VERSION` file does NOT use the `v` prefix
 - tags and changelog entries DO use the `v` prefix
+- GitHub Release titles MUST be exactly the tag name (for example, `v2.4.2`);
+  never prefix release titles with the product or service name (for example,
+  do not use `GPT-RAG UI v2.4.2` or `gpt-rag-ui v2.4.2`).
 
 Examples:
 


### PR DESCRIPTION
Adds an explicit Copilot instruction that GitHub Release titles must be exactly the tag name (for example, `v2.3.10`) and must not include product/service prefixes.