### PR TITLE
chore(deploy): warn when $env:APP_CONFIG_ENDPOINT diverges from azd env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+- **Warn when `$env:APP_CONFIG_ENDPOINT` diverges from the azd environment during component deploy (issue [Azure/GPT-RAG#491](https://github.com/Azure/GPT-RAG/issues/491)):** `scripts/deploy.ps1` and `scripts/deploy.sh` now read both the shell `APP_CONFIG_ENDPOINT` and the azd env value and, when both are present and disagree (trimmed, case-insensitive), print a yellow warning that shows both values, states which one is being used (the shell value still wins, preserving existing precedence for jumpbox and CI flows), and tells the operator how to clear the shell override (`Remove-Item env:APP_CONFIG_ENDPOINT` in PowerShell, `unset APP_CONFIG_ENDPOINT` in bash). When only one source is set, the previous behavior is unchanged.
+
+## [Unreleased]
+
 ### Fixed
 - **Forward uploader identity for document ACLs (issue #478):** The ingestion payload built by `ingestion_client.py` now includes the authenticated uploader's object id as `securityUserIds` so the ingestion service can stamp document ACLs. This keeps uploaded documents retrievable by their uploader on permission-trimmed search indexes. Anonymous/placeholder ids are not sent.
 

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -256,12 +256,27 @@ function Confirm-ContainerAppImage {
 }
 
 Write-Host ''
+$shellAppConfigEndpoint = $null
 if ($env:APP_CONFIG_ENDPOINT -and $env:APP_CONFIG_ENDPOINT.Trim() -ne '') {
-    $APP_CONFIG_ENDPOINT = $env:APP_CONFIG_ENDPOINT.Trim()
+    $shellAppConfigEndpoint = $env:APP_CONFIG_ENDPOINT.Trim()
+}
+$azdAppConfigEndpoint = Get-AzdEnvValue -Key 'APP_CONFIG_ENDPOINT'
+
+if ($shellAppConfigEndpoint -and $azdAppConfigEndpoint -and
+    ($shellAppConfigEndpoint.ToLowerInvariant() -ne $azdAppConfigEndpoint.ToLowerInvariant())) {
+    Write-Yellow 'Warning: APP_CONFIG_ENDPOINT in your shell does not match the azd environment.'
+    Write-Yellow ("  shell  (`$env:APP_CONFIG_ENDPOINT): {0}" -f $shellAppConfigEndpoint)
+    Write-Yellow ("  azd env (APP_CONFIG_ENDPOINT)    : {0}" -f $azdAppConfigEndpoint)
+    Write-Yellow ("Using shell value: {0}" -f $shellAppConfigEndpoint)
+    Write-Yellow 'To use the azd env value instead, run: Remove-Item env:APP_CONFIG_ENDPOINT'
+}
+
+if ($shellAppConfigEndpoint) {
+    $APP_CONFIG_ENDPOINT = $shellAppConfigEndpoint
     Write-Green "Using APP_CONFIG_ENDPOINT from environment: $APP_CONFIG_ENDPOINT"
 } else {
     Write-Blue 'Fetching APP_CONFIG_ENDPOINT from azd env...'
-    $APP_CONFIG_ENDPOINT = Get-AzdEnvValue -Key 'APP_CONFIG_ENDPOINT'
+    $APP_CONFIG_ENDPOINT = $azdAppConfigEndpoint
 }
 
 if ([string]::IsNullOrWhiteSpace($APP_CONFIG_ENDPOINT)) {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -217,11 +217,30 @@ verify_containerapp_image() {
 }
 
 echo
+shell_app_config_endpoint=""
 if [[ -n "${APP_CONFIG_ENDPOINT:-}" ]]; then
+  shell_app_config_endpoint="$(printf "%s" "${APP_CONFIG_ENDPOINT}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+fi
+azd_app_config_endpoint="$(get_azd_value "APP_CONFIG_ENDPOINT")"
+
+if [[ -n "$shell_app_config_endpoint" && -n "$azd_app_config_endpoint" ]]; then
+  shell_lower="$(printf "%s" "$shell_app_config_endpoint" | tr '[:upper:]' '[:lower:]')"
+  azd_lower="$(printf "%s" "$azd_app_config_endpoint" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$shell_lower" != "$azd_lower" ]]; then
+    warn "Warning: APP_CONFIG_ENDPOINT in your shell does not match the azd environment."
+    warn "  shell  (\$APP_CONFIG_ENDPOINT)  : ${shell_app_config_endpoint}"
+    warn "  azd env (APP_CONFIG_ENDPOINT)  : ${azd_app_config_endpoint}"
+    warn "Using shell value: ${shell_app_config_endpoint}"
+    warn "To use the azd env value instead, run: unset APP_CONFIG_ENDPOINT"
+  fi
+fi
+
+if [[ -n "$shell_app_config_endpoint" ]]; then
+  APP_CONFIG_ENDPOINT="$shell_app_config_endpoint"
   success "Using APP_CONFIG_ENDPOINT from environment: ${APP_CONFIG_ENDPOINT}"
 else
   info "Fetching APP_CONFIG_ENDPOINT from azd env..."
-  APP_CONFIG_ENDPOINT="$(get_azd_value "APP_CONFIG_ENDPOINT")"
+  APP_CONFIG_ENDPOINT="$azd_app_config_endpoint"
 fi
 
 if [[ -z "${APP_CONFIG_ENDPOINT:-}" ]]; then


### PR DESCRIPTION
## Purpose

Resolves part of umbrella issue **Azure/GPT-RAG#491** (DX: warn when `https://appcs-jfybdkewftpj6.azconfig.io` diverges from azd env during component deploy).

When `https://appcs-jfybdkewftpj6.azconfig.io` is set in the shell but disagrees with the active `azd env` value, `scripts/deploy.ps1` and `scripts/deploy.sh` silently picked the shell value (intended precedence for jumpbox/CI), which made stale shell exports an easy way to deploy against the wrong App Configuration.

## What changed

- Both deploy scripts now read both sources and, when both are present and differ (trimmed, case-insensitive), print a yellow warning that:
  - shows both values (shell vs azd env),
  - declares which one is being used (shell still wins ΓÇö precedence preserved),
  - tells the operator how to clear the shell override (`Remove-Item env:APP_CONFIG_ENDPOINT` in PowerShell, `unset APP_CONFIG_ENDPOINT` in bash).
- When only one source is set, the message is unchanged from before.
- No precedence change. No behavior change for jumpbox or CI flows.

## Target

- Source: `feature/491-warn-app-config-endpoint-divergence`
- Target: `develop`

## Cross-reference

This is one of three coordinated PRs (orchestrator + ingestion + ui). The other two will be linked in the umbrella issue comment.

## Validation

- `scripts/deploy.ps1` parsed with `[scriptblock]::Create((Get-Content -Raw ...))` ΓÇö OK.
- `scripts/deploy.sh` parsed with `bash -n` ΓÇö OK.
- Smoke test of the modified block in PS and bash with mocked `Get-AzdEnvValue` / `get_azd_value` covering: divergence, case-insensitive match, shell-only, azd-only. Warning fires only on divergence; legacy paths unchanged.
- No `azd up`/`azd deploy` run ΓÇö change is purely diagnostic.




## Sibling PRs (umbrella Azure/GPT-RAG#491)

- Azure/gpt-rag-ingestion#208 — https://github.com/Azure/gpt-rag-ingestion/pull/208
- Azure/gpt-rag-orchestrator#203 — https://github.com/Azure/gpt-rag-orchestrator/pull/203
